### PR TITLE
Fixed breadcrumbs

### DIFF
--- a/_includes/_breadcrumbs.html
+++ b/_includes/_breadcrumbs.html
@@ -1,17 +1,21 @@
 {% comment %}
 *
 *  http://stackoverflow.com/questions/9612235/what-are-some-good-ways-to-implement-breadcrumbs-on-a-jekyll-site
+*  https://phlow.github.io/feeling-responsive/
+*  https://jekyllcodex.org/without-plugin/breadcrumbs/#
 *
 {% endcomment %}
 
 <div class="breadcrumbs" aria-label="breadcrumbs">
- <a href="{{ site.url }}{{ site.baseurl }}">{{ site.data.language.breadcrumb_start }}</a>
- {% assign crumbs = page.url | split: '/' %}
-   {% for crumb in crumbs offset: 1 %}
-    {% if forloop.last %}
+  <a href="/">Home</a>
+  {% if page.url != site.url and page.url != site.url | append: site.baseurl %}
+    {% assign crumbs = page.url | split: '/' %}
+    {% for crumb in crumbs %}
+      {% if forloop.last %}
         / <a class="current">{{ page.title }}</a>
-    {% else %}
-        / <a href="{{ site.url }}{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{{ crumb | replace:'-',' ' }}</a>
-    {% endif %}
-  {% endfor %}
+      {% elsif forloop.index > 2 %}  <!-- Prevent links to `/` and `pages/` -->
+        / <a href="{% assign crumb_limit = forloop.index %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{{ crumb | replace:'-',' ' | capitalize }}</a>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 </div>

--- a/pages/til/jekyll/create-automatic-file-index.md
+++ b/pages/til/jekyll/create-automatic-file-index.md
@@ -10,7 +10,7 @@ To automatically create a list of files, use the following snippet.
 ### List all pages in the same directory
 
 {% raw %}
-```
+```html
 {% assign pages = site.pages | sort: 'title' %}
 
 <ul>
@@ -27,7 +27,7 @@ To automatically create a list of files, use the following snippet.
 ### List all pages in a specific directory
 
 {% raw %}
-```
+```html
 {% assign pages = site.pages | sort: 'title' %}
 
 {% assign target_dir = page.dir | append: 'path/to/target_dir/' %}

--- a/pages/til/jekyll/create-breadcrumbs-for-website.md
+++ b/pages/til/jekyll/create-breadcrumbs-for-website.md
@@ -1,0 +1,32 @@
+# Create breadcrumbs for website
+
+## How To
+
+Using Jekyll, we can dynamically get path info from the current page hierarchy.
+
+1. Get tha page url and split it into crumbs
+2. For each crumb, until the last, create a set of HTML links
+
+### Start the breadcrumbs from the site's base URL
+
+{% raw %}
+```html
+<div class="breadcrumbs" aria-label="breadcrumbs">
+    <a href="{{ site.url }}{{ site.baseurl }}">{{ site.data.language.breadcrumb_start }}</a>
+    {% assign crumbs = page.url | split: '/' %}
+    {% for crumb in crumbs offset: 1 %}
+        {% if forloop.last %}
+            / <a class="current">{{ page.title }}</a>
+        {% else %}
+            / <a href="{{ site.url }}{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{{ crumb | replace:'-',' ' }}</a>
+        {% endif %}
+    {% endfor %}
+</div>
+```
+{% endraw %}
+
+## References
+
+* [What are some good ways to implement breadcrumbs on a Jekyll site](http://stackoverflow.com/questions/9612235/what-are-some-good-ways-to-implement-breadcrumbs-on-a-jekyll-site)
+* [Feeling Responsive - Jekyll theme](https://phlow.github.io/feeling-responsive/)
+* https://jekyllcodex.org/without-plugin/breadcrumbs/#


### PR DESCRIPTION
Fixed by removing `site.url`/`site.baseurl` references and using the root `/`.